### PR TITLE
Unpin dependency versions to allow installing on vite 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@dansvel/vite-plugin-markdown",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dansvel/vite-plugin-markdown",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "front-matter": "^4.0.2",
-        "marked": "^4.0.7",
-        "vite": "^2.7.1"
+        "front-matter": "*",
+        "marked": "*",
+        "vite": "*"
       },
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dansvel/vite-plugin-markdown",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "dan",
   "license": "MIT",
   "description": "A plugin for importing markdown files in Vite",
@@ -24,9 +24,9 @@
     }
   },
   "dependencies": {
-    "front-matter": "^4.0.2",
-    "marked": "^4.0.7",
-    "vite": "^2.7.1"
+    "front-matter": "*",
+    "marked": "*",
+    "vite": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
This change simply replaces dependency versions in package.json with "any version" (https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies).
Ran into this issue after upgrading to Vite v3, as it triggered a dependency conflict. This will allow the package to work on whatever version of Vite it is, as it's quite unlikely to ever bump into a conflict that would actually matter. 

Bumped the version of the package as well so you can just merge and push to npm!

Thanks for the plugin!