### PR TITLE
Silence missing sourcemap warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dansvel/vite-plugin-markdown",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": "dan",
   "license": "MIT",
   "description": "A plugin for importing markdown files in Vite",

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,9 @@ export default (options: PluginOptions): Plugin => {
       content.add(result)
 
       return {
-        code: `${content.export()}\n export default { ${content.variables.join(', ')} }`
+        code: `${content.export()}\n export default { ${content.variables.join(', ')} }`,
         // code: `export default ${JSON.stringify(result)}`,
+        map: null
       }
     }
   }


### PR DESCRIPTION
When sourcemaps have been enabled, Vite will spit out the following warning:
> [plugin vite-plugin-markdown] Sourcemap is likely to be incorrect: a plugin (vite-plugin-markdown) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help

Considering that the markdown conversion will not create JS exceptions, it's safe to explicitly tell vite that this plugin does not produce sourcemaps (nothing to see here).

This fixes the warning in the terminal